### PR TITLE
UE4 Compability by template-based backdoor

### DIFF
--- a/SlateIconBrowser.uplugin
+++ b/SlateIconBrowser.uplugin
@@ -9,7 +9,6 @@
   "CreatedByURL": "https://sirjofri.de",
   "DocsURL": "https://github.com/sirjofri/SlateIconBrowser/blob/master/Readme.md",
   "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/7f51deb58ead4fed88abc798ca7c9ae4",
-  "EngineVersion": "5.1.0",
   "CanContainContent": false,
   "IsBetaVersion": false,
   "IsExperimentalVersion": false,

--- a/Source/SlateIconBrowser/Private/SlateIconBrowser.cpp
+++ b/Source/SlateIconBrowser/Private/SlateIconBrowser.cpp
@@ -58,6 +58,10 @@ TSharedRef<SDockTab> FSlateIconBrowserModule::OnSpawnPluginTab(const FSpawnTabAr
 	CacheAllLines();
 
 	return SNew(SDockTab)
+		.OnTabClosed_Lambda([](TSharedRef<SDockTab>)
+		{
+			GetMutableDefault<USlateIconBrowserUserSettings>()->FilterString = TEXT("");
+		})
 		.TabRole(ETabRole::NomadTab)
 		[
 			// Put your tab content here!

--- a/Source/SlateIconBrowser/Private/SlateIconBrowserHacker.cpp
+++ b/Source/SlateIconBrowser/Private/SlateIconBrowserHacker.cpp
@@ -1,0 +1,64 @@
+#include "SlateIconBrowserHacker.h"
+
+
+TSet<FName> HackerMisc::
+GetStyleKeys(const FSlateStyleSet* Style)
+{
+	TSet<FName> AllKeys;
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_WidgetStyleValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_FloatValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_Vector2DValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_ColorValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_SlateColorValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_MarginValues(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_BrushResources(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_Sounds(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	{
+		TArray<FName> Keys;
+		Hacker::Steal_FontInfoResources(Style)->GenerateKeyArray(Keys);
+		AllKeys.Append(Keys);
+	}
+
+	return AllKeys;
+}

--- a/Source/SlateIconBrowser/Private/SlateIconBrowserStyle.cpp
+++ b/Source/SlateIconBrowser/Private/SlateIconBrowserStyle.cpp
@@ -5,9 +5,15 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Slate/SlateGameResources.h"
 #include "Interfaces/IPluginManager.h"
-#include "Styling/SlateStyleMacros.h"
 
+#if ENGINE_MAJOR_VERSION == 5
+#include "Styling/SlateStyleMacros.h"
 #define RootToContentDir Style->RootToContentDir
+#else
+#define IMAGE_BRUSH( RelativePath, ... ) FSlateImageBrush( Style->RootToContentDir( RelativePath, TEXT(".png") ), __VA_ARGS__ )
+#endif
+
+
 
 TSharedPtr<FSlateStyleSet> FSlateIconBrowserStyle::StyleInstance = nullptr;
 
@@ -41,8 +47,11 @@ TSharedRef< FSlateStyleSet > FSlateIconBrowserStyle::Create()
 	TSharedRef< FSlateStyleSet > Style = MakeShareable(new FSlateStyleSet("SlateIconBrowserStyle"));
 	Style->SetContentRoot(IPluginManager::Get().FindPlugin("SlateIconBrowser")->GetBaseDir() / TEXT("Resources"));
 
+#if ENGINE_MAJOR_VERSION == 5
 	Style->Set("SlateIconBrowser.Icon", new IMAGE_BRUSH_SVG(TEXT("Icon"), Icon20x20));
-
+#else
+	Style->Set("SlateIconBrowser.Icon", new IMAGE_BRUSH(TEXT("Icon128"), Icon20x20));
+#endif
 	return Style;
 }
 

--- a/Source/SlateIconBrowser/Public/SlateIconBrowser.h
+++ b/Source/SlateIconBrowser/Public/SlateIconBrowser.h
@@ -15,6 +15,14 @@ class STextBlock;
 template<typename T> class SListView;
 template<typename T> class SComboBox;
 
+
+#if ENGINE_MAJOR_VERSION == 4
+#define EDITOR_STYLE_SAFE() FEditorStyle
+#else
+#define EDITOR_STYLE_SAFE() FAppStyle
+#endif
+
+
 class FSlateIconBrowserModule : public IModuleInterface
 {
 public:

--- a/Source/SlateIconBrowser/Public/SlateIconBrowserHacker.h
+++ b/Source/SlateIconBrowser/Public/SlateIconBrowserHacker.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "Styling/SlateStyle.h"
+
+
+#define DECLARE_THIEF_FUNCTION(Class, MemberType, MemberName)\
+	template <MemberType Class::* MEMBER_PTR>\
+	struct GenerateThiefFunction_##MemberName{\
+		friend MemberType* Steal_##MemberName(Class* Victim)       { return &(Victim->*MEMBER_PTR); }\
+		friend MemberType* Steal_##MemberName(Class& Victim)       { return &(Victim.*MEMBER_PTR);  }\
+		friend MemberType* Steal_##MemberName(const Class* Victim) { return &(const_cast<Class*>(Victim)->*MEMBER_PTR);  }\
+		friend MemberType* Steal_##MemberName(const Class& Victim) { return &(const_cast<Class&>(Victim).*MEMBER_PTR);   }\
+	};\
+	template struct GenerateThiefFunction_##MemberName<&Class::MemberName>;\
+	MemberType* Steal_##MemberName(Class* Victim);\
+	template struct GenerateThiefFunction_##MemberName<&Class::MemberName>;\
+	MemberType* Steal_##MemberName(Class& Victim);\
+	template struct GenerateThiefFunction_##MemberName<&Class::MemberName>;\
+	MemberType* Steal_##MemberName(const Class* Victim);\
+	template struct GenerateThiefFunction_##MemberName<&Class::MemberName>;\
+	MemberType* Steal_##MemberName(const Class& Victim);
+
+
+namespace Hacker
+{
+	typedef TMap<FName, TSharedRef<FSlateWidgetStyle>> FWidgetStyleValuesMap;
+	typedef TMap<FName, float> FFloatValuesMap;
+	typedef TMap<FName, FVector2D> FVector2DValuesMap;
+	typedef TMap<FName, FLinearColor> FFColorValuesMap;
+	typedef TMap<FName, FSlateColor> FSlateColorValuesMap;
+	typedef TMap<FName, FMargin> FMarginValuesMap;
+	typedef TMap<FName, FSlateBrush*> FBrushResourcesMap;
+	typedef TMap<FName, FSlateSound> FSoundsMap;
+	typedef TMap<FName, FSlateFontInfo> FFontInfoResourcesMap;
+
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FWidgetStyleValuesMap, WidgetStyleValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FFloatValuesMap, FloatValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FVector2DValuesMap, Vector2DValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FFColorValuesMap, ColorValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FSlateColorValuesMap, SlateColorValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FMarginValuesMap, MarginValues)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FBrushResourcesMap, BrushResources)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FSoundsMap, Sounds)
+	DECLARE_THIEF_FUNCTION(FSlateStyleSet, FFontInfoResourcesMap, FontInfoResources)
+}
+
+
+namespace HackerMisc
+{
+	TSet<FName> GetStyleKeys(const FSlateStyleSet* Style);
+}
+
+#undef DECLARE_THIEF_FUNCTION

--- a/Source/SlateIconBrowser/Public/SlateIconBrowserUserSettings.h
+++ b/Source/SlateIconBrowser/Public/SlateIconBrowserUserSettings.h
@@ -20,7 +20,9 @@ class USlateIconBrowserUserSettings : public UObject
 	GENERATED_BODY()
 	
 public:
-	UPROPERTY(Config)
+	// I think there is no need to make filter string serialized by config
+	// This makes it cumbersome if I open IconBrowser next time but I just want to search another Brush
+	UPROPERTY()
 	FString FilterString;
 
 	UPROPERTY(Config)

--- a/Source/SlateIconBrowser/SlateIconBrowser.Build.cs
+++ b/Source/SlateIconBrowser/SlateIconBrowser.Build.cs
@@ -36,7 +36,11 @@ public class SlateIconBrowser : ModuleRules
 			{
 				"Projects",
 				"InputCore",
+				
+#if UE_5_0_OR_LATER
 				"EditorFramework",
+#endif
+				
 				"UnrealEd",
 				"CoreUObject",
 				"Engine",


### PR DESCRIPTION
Many WIP game developements are still running in UE4. Actually UE4 does not support the code like this `TSet<FName> keys = Style->GetStyleKeys();` . And all style members are private, so we cannot use this tool directly on UE4. 
Thus, a Template-Based backdoor is used to force access private memebers of `FStyleSet` in UE4

ps. some user experience optimization is included, including:
1 config serialize `FilterString` make using not very fluent so `Config` specifier is removed
2 sort style set name to make them in order